### PR TITLE
Add `Layout` to metric names in servo reports.

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 static USER_FACING_PAINT_METRICS: &str = "FP FCP";
-static REAL_SERVO_EVENTS: &str = "Compositing LayoutPerform ScriptEvaluate ScriptParseHTML";
+static REAL_SERVO_EVENTS: &str = "Compositing LayoutPerform Layout ScriptEvaluate ScriptParseHTML";
 static REAL_CHROMIUM_EVENTS: &str = "EvaluateScript FunctionCall Layerize Layout Paint ParseHTML PrePaint TimerFire UpdateLayoutTree";
 static RENDERING_PHASES_MODEL_EVENTS: &str = "Parse Script Layout Rasterise";
 static OVERALL_RENDERING_TIME_MODEL_EVENTS: &str = "Renderer";

--- a/src/servo.rs
+++ b/src/servo.rs
@@ -25,10 +25,10 @@ use crate::{
     },
 };
 
-static RENDERER_NAMES: &'static str = "ScriptParseHTML ScriptEvaluate LayoutPerform Compositing";
+static RENDERER_NAMES: &'static str = "ScriptParseHTML ScriptEvaluate LayoutPerform Layout Compositing";
 static PARSE_NAMES: &'static str = "ScriptParseHTML";
 static SCRIPT_NAMES: &'static str = "ScriptEvaluate";
-static LAYOUT_NAMES: &'static str = "LayoutPerform";
+static LAYOUT_NAMES: &'static str = "LayoutPerform Layout";
 static RASTERISE_NAMES: &'static str = "Compositing";
 static NO_URL_NAMES: &'static str = "Compositing IpcReceiver";
 static HTML_ONLY_NAMES: &'static str =


### PR DESCRIPTION
This updates the naming categories as per https://github.com/servo/servo/pull/37833

Keeping `LayoutPerform` for backward compatibility.  