### PR TITLE
Support CPU disabling boost for Intel CPUs as well.

### DIFF
--- a/isolate-cpu-for-shell.sh
+++ b/isolate-cpu-for-shell.sh
@@ -36,6 +36,8 @@ disable_cpu_boost() {
         echo 0 > /sys/devices/system/cpu/cpufreq/boost
     elif [ -f /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
         echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+    else
+        >&2 echo 'Warning: don’t know how to disable CPU boost for this CPU!'
     fi
 }
 

--- a/isolate-cpu-for-shell.sh
+++ b/isolate-cpu-for-shell.sh
@@ -30,6 +30,15 @@ usage() {
     exit 1
 }
 
+disable_cpu_boost() {
+    # For the AMD 7950X, this requires Linux 6.11.
+    if [ -f /sys/devices/system/cpu/cpufreq/boost ]; then
+        echo 0 > /sys/devices/system/cpu/cpufreq/boost
+    elif [ -f /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+        echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+    fi
+}
+
 if [ $# -gt 1 ]; then
     shell_pid=${1:-':???:'}; shift
     for cpu; do
@@ -51,8 +60,8 @@ if test -r /proc/$shell_pid/exe ; then
     echo 0 > /proc/sys/kernel/perf_event_paranoid
 
     # Disable CPU frequency boost.
-    # For the AMD 7950X, this requires Linux 6.11.
-    echo 0 > /sys/devices/system/cpu/cpufreq/boost
+    >&2 printf 'Disabling CPU frequency boost...\n'
+    disable_cpu_boost
 
     # Online all CPUs that can be offlined, in case we are rerunning this script with new CPU IDs.
     # This is also necessary to avoid write errors with EBUSY in the scaling_governor step.
@@ -110,7 +119,7 @@ if test -r /proc/$shell_pid/exe ; then
     # Put the given pid in the shield cgroup.
     echo $shell_pid > /sys/fs/cgroup/shield/cgroup.procs
     ls -al /proc/$shell_pid/exe
-    head /sys/fs/cgroup/shield/cpuset.cpus /sys/fs/cgroup/shield/cgroup.procs /sys/fs/cgroup/shield/cpuset.cpus.partition /sys/devices/system/cpu/cpufreq/boost
+    head /sys/fs/cgroup/shield/cpuset.cpus /sys/fs/cgroup/shield/cgroup.procs /sys/fs/cgroup/shield/cpuset.cpus.partition
 else
     >&2 echo 'Error: failed to find pid'
 fi

--- a/undo-cpu-isolation.sh
+++ b/undo-cpu-isolation.sh
@@ -9,9 +9,18 @@ all_cpu_ids() {
     lscpu --parse=cpu | rg -v '^#'
 }
 
+reset_cpu_boost() {
+    # For the AMD 7950X, this requires Linux 6.11.
+    if [ -f /sys/devices/system/cpu/cpufreq/boost ]; then
+        echo 1 > /sys/devices/system/cpu/cpufreq/boost
+    elif [ -f /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+        echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo
+    fi
+}
+
 echo 2 > /proc/sys/kernel/randomize_va_space
 echo 4 > /proc/sys/kernel/perf_event_paranoid
-echo 1 > /sys/devices/system/cpu/cpufreq/boost
+reset_cpu_boost
 # for scg in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor ; do
 #     echo schedutil > $scg || :
 # done

--- a/undo-cpu-isolation.sh
+++ b/undo-cpu-isolation.sh
@@ -15,6 +15,8 @@ reset_cpu_boost() {
         echo 1 > /sys/devices/system/cpu/cpufreq/boost
     elif [ -f /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
         echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo
+    else
+        >&2 echo 'Warning: don’t know how to reset CPU boost for this CPU!'
     fi
 }
 


### PR DESCRIPTION
It first checks for CPU_VENDOR, disables the boost accordingly.

Earlier script just fails for Intel based CPU.

cc: @xiaochengh